### PR TITLE
ci(docker): changing docker release

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -304,11 +304,14 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn --prefer-offline
+        run: yarn install --frozen-lockfile --prefer-offline
 
       - name: Build
-        run: |
-          yarn build
+        run: yarn build:production
+        env:
+          DISABLE_ESLINT_PLUGIN: true
+          REACT_APP_NRFESAMPLEAPP_VERSION: ${{ env.REACT_APP_NRFESAMPLEAPP_VERSION }}
+          REACT_APP_SERVER_URL: ${{ secrets.REACT_APP_SERVER_URL }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,10 @@
 FROM node:16-bullseye
-
-ARG REACT_APP_NRFESAMPLEAPP_VERSION
-ARG REACT_APP_SERVER_URL
-
-WORKDIR /app
-COPY . .
-
-ENV DISABLE_ESLINT_PLUGIN=true
-ENV REACT_APP_NRFESAMPLEAPP_VERSION=$REACT_APP_NRFESAMPLEAPP_VERSION
-ENV REACT_APP_SERVER_URL=$REACT_APP_SERVER_URL
+LABEL maintainer="Paulo Gomes da Cruz Junior <paulo.cruz@encora.com>"
 
 RUN yarn global add serve
 
-# Install dependencies
-RUN yarn install --frozen-lockfile
-
-# Build to production
-RUN yarn build:production
+WORKDIR /app
+COPY build/ .
 
 EXPOSE 3000
 


### PR DESCRIPTION
changing release to leverage CI cache

# Description

Changed the release strategy to leverage the GitHub actions cache to build the artifact before packing it into an image.

Also removed a few parameters that don't make any sense at the moment

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

A local image was generated and executed to make sure the process was done correctly.

- [x] Generated a new local image
- [x] Executed the new local image

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

A future review of the image and how we can reduce it's size is suggested.