### PR TITLE
fix: remove webkit/change firefox image

### DIFF
--- a/.github/workflows/cypress-nightly.yml
+++ b/.github/workflows/cypress-nightly.yml
@@ -39,7 +39,7 @@ jobs:
   e2e-firefox:
     runs-on: ubuntu-20.04
     container:
-      image: cypress/browsers:node18.6.0-chrome105-ff104
+      image: cypress/included:11.2.0
       options: --user 1001
     name: E2E on Firefox
     steps:
@@ -47,9 +47,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          browser: firefox
+        run: cypress run --browser firefox
       
       - name: Upload screenshots on failure
         uses: actions/upload-artifact@v3
@@ -63,32 +61,6 @@ jobs:
         if: always()
         with:
           name: cypress-videos-firefox
-          path: cypress/videos
-
-  e2e-webkit:
-    runs-on: macos-latest
-    name: E2E on Webkit
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          browser: webkit
-      
-      - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots-webkit
-          path: cypress/screenshots
-      
-      - name: Upload videos
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cypress-videos-webkit
           path: cypress/videos
 
   e2e-edge:


### PR DESCRIPTION
# Description

Removed Webkit from the browser list as it's still in an experimental phase with some bugs. Also changed firefox to use a complete image with Cypress already pre-installed removing the step to install the project dependencies.

Fixes # (227)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with the same docker image used in the GH action.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
